### PR TITLE
Store images in local instead of AWS S3 for now

### DIFF
--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -148,5 +148,5 @@ Rails.application.configure do
   # We don't need schema dumps in this environment
   config.active_record.dump_schema_after_migration = false
 
-  config.active_storage.service = :amazon
+  config.active_storage.service = :local
 end


### PR DESCRIPTION
We want to skip the setup and configuration of the S3 account as next.donalo.org is for demo purposes only.