### PR TITLE
Do not load the active storage decorator

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -239,7 +239,7 @@ module Kassi
     ActiveSupport::Deprecation.warn("Support for Google Analytics is deprecated, please use Google Tag Manager instead") if APP_CONFIG.use_google_analytics.to_s == "true"
 
     config.after_initialize do
-      require File.expand_path('../../lib/active_storage_decorator', __FILE__)
+      # require File.expand_path('../../lib/active_storage_decorator', __FILE__)
     end
   end
 end


### PR DESCRIPTION
This requires us to still set AWS credentials.

```
$ bundle exec rake db:migrate
rake aborted!
Aws::Sigv4::Errors::MissingCredentialsError: Cannot load `Rails.config.active_storage.service`:
missing credentials, provide credentials with one of the following options:
  - :access_key_id and :secret_access_key
  - :credentials
  - :credentials_provider
/var/www/donalo/shared/vendor/bundle/ruby/2.6.0/gems/aws-sigv4-1.1.0/lib/aws-sigv4/signer.rb:612:in `extract_credentials_provider'
/var/www/donalo/shared/vendor/bundle/ruby/2.6.0/gems/aws-sigv4-1.1.0/lib/aws-sigv4/signer.rb:122:in `initialize'
(...)
```

We disable this temporally until we don't get to deploy the app cleanly
and figure out why is this decorator needed.