### PR TITLE
Use current/ as Unicorn workin directory

### DIFF
--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,7 +1,7 @@
 deploy_to = '/var/www/donalo/'
 shared_path = "#{deploy_to}/shared"
 
-working_directory deploy_to
+working_directory "#{deploy_to}/current"
 
 pid "#{shared_path}/pids/unicorn.pid"
 stderr_path "#{shared_path}/log/unicorn.err.log"


### PR DESCRIPTION
This came up with in the last deploy run from https://github.com/coopdevs/donalo/pull/47.

```
Dec 17 11:08:24 staging systemd[1]: Started Donalo Unicorn app server.
Dec 17 11:08:25 staging donalo-unicorn[17496]: bundler: failed to load command: unicorn (/var/www/donalo/releases/20191217100324Z/vendor/bundle/ruby/2.6.0/bin/unicorn)
Dec 17 11:08:25 staging donalo-unicorn[17496]: ArgumentError: config_file=config/unicorn.rb would not be accessible in working_directory=/var/www/donalo
Dec 17 11:08:25 staging donalo-unicorn[17496]:   /var/www/donalo/shared/vendor/bundle/ruby/2.6.0/gems/unicorn-5.5.1/lib/unicorn/configurator.rb:603:in `working_directory'
Dec 17 11:08:25 staging donalo-unicorn[17496]:   config/unicorn.rb:4:in `reload'
Dec 17 11:08:25 staging donalo-unicorn[17496]:   /var/www/donalo/shared/vendor/bundle/ruby/2.6.0/gems/unicorn-5.5.1/lib/unicorn/configurator.rb:84:in `instance_eval'
Dec 17 11:08:25 staging donalo-unicorn[17496]:   /var/www/donalo/shared/vendor/bundle/ruby/2.6.0/gems/unicorn-5.5.1/lib/unicorn/configurator.rb:84:in `reload'
Dec 17 11:08:25 staging donalo-unicorn[17496]:   /var/www/donalo/shared/vendor/bundle/ruby/2.6.0/gems/unicorn-5.5.1/lib/unicorn/configurator.rb:77:in `initialize'
Dec 17 11:08:25 staging donalo-unicorn[17496]:   /var/www/donalo/shared/vendor/bundle/ruby/2.6.0/gems/unicorn-5.5.1/lib/unicorn/http_server.rb:79:in `new'
Dec 17 11:08:25 staging donalo-unicorn[17496]:   /var/www/donalo/shared/vendor/bundle/ruby/2.6.0/gems/unicorn-5.5.1/lib/unicorn/http_server.rb:79:in `initialize'
Dec 17 11:08:25 staging donalo-unicorn[17496]:   /var/www/donalo/shared/vendor/bundle/ruby/2.6.0/gems/unicorn-5.5.1/bin/unicorn:128:in `new'
Dec 17 11:08:25 staging donalo-unicorn[17496]:   /var/www/donalo/shared/vendor/bundle/ruby/2.6.0/gems/unicorn-5.5.1/bin/unicorn:128:in `<top (required)>'
Dec 17 11:08:25 staging donalo-unicorn[17496]:   /var/www/donalo/releases/20191217100324Z/vendor/bundle/ruby/2.6.0/bin/unicorn:23:in `load'
Dec 17 11:08:25 staging donalo-unicorn[17496]:   /var/www/donalo/releases/20191217100324Z/vendor/bundle/ruby/2.6.0/bin/unicorn:23:in `<top (required)>'
Dec 17 11:08:25 staging systemd[1]: donalo.service: Main process exited, code=exited, status=1/FAILURE
Dec 17 11:08:25 staging systemd[1]: donalo.service: Failed with result 'exit-code'.
```