### PR TITLE
Revert "Configure SMTP vars"

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -17,12 +17,5 @@ test:
 staging:
   secret_key_base: <%= ENV['SECRET_TOKEN'] %>
 
-  mail_delivery_method: smtp
-  smtp_email_address: <%= ENV.fetch('SMTP_EMAIL') %>
-  smtp_email_port: <%= ENV.fetch('SMTP_PORT', 587) %>
-  smtp_email_user_name: <%= ENV.fetch('SMTP_USERNAME') %>
-  smtp_email_password: <%= ENV.fetch('SMTP_PASSWORD') %>
-  smtp_email_domain: <%= ENV.fetch('SMTP_DOMAIN') %>
-
 production:
   # Add local `production` environment configuration overrides here


### PR DESCRIPTION
This reverts commit 5c1a862f076b9ee483505d709a5b7c14ddb77aa4.

In https://github.com/coopdevs/donalo/pull/49 we changed the way we pass
config vars in.