### PR TITLE
Log Delayed Job in log/delayed_job.log

### DIFF
--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -54,3 +54,4 @@ Delayed::Worker.default_priority = 5
 Delayed::Worker.default_queue_name = "default"
 Delayed::Worker.plugins << DelayedJobLoggerPlugin
 Delayed::Worker.plugins << Delayed::Plugins::RequestStorePlugin
+Delayed::Worker.logger = Logger.new(File.join(Rails.root, 'log', 'delayed_job.log'))


### PR DESCRIPTION
This will help debug the app configuration. Although Sharetribe's DelayedJobLoggerPlugin uses a Rails.logger, I can't find anything about delayed_jobs in log/*.