### PR TITLE
Remove Rails backtrace silencers

### DIFF
--- a/config/initializers/backtrace_silencers.rb
+++ b/config/initializers/backtrace_silencers.rb
@@ -4,4 +4,4 @@
 # Rails.backtrace_cleaner.add_silencer { |line| line =~ /my_noisy_library/ }
 
 # You can also remove all the silencers if you're trying to debug a problem that might stem from framework code.
-# Rails.backtrace_cleaner.remove_silencers!
+Rails.backtrace_cleaner.remove_silencers!


### PR DESCRIPTION
This way we get to see the whole backtrace including gems, which is
incredibly useful to debug issues, especially now that there are some
things still failing.

Before we could only see things like

```
SocketError (getaddrinfo: Name or service not known):

app/utils/mail_carrier.rb:12:in `deliver_now'
app/utils/mail_carrier.rb:8:in `deliver_later'
app/controllers/admin/communities_controller.rb:170:in `test_welcome_email'
lib/rack_middleware/session_context_middleware.rb:15:in `call'
lib/rack_middleware/marketplace_lookup.rb:35:in `call'
lib/rack_middleware/custom_cookie_renamer.rb:11:in `call'
lib/rack_middleware/enforce_ssl.rb:23:in `call'
lib/rack_middleware/health_check.rb:12:in `call'
{"method":"GET","path":"/500","format":"html","controller":"ErrorsController","action":"server_error","status":500,"duration":16.93,"view":9.24,"db":0.06,"params":{"locale":"es","id":"1"},"host":null,"community_id":null,"current_user_id":null,"user_agent":null,"referer":null,"forwarded_for":null,"request_uuid":null}
```

And now they become

```
SocketError (getaddrinfo: Name or service not known):

/home/donalo/.rbenv/versions/2.6.2/lib/ruby/2.6.0/net/smtp.rb:539:in `initialize'
/home/donalo/.rbenv/versions/2.6.2/lib/ruby/2.6.0/net/smtp.rb:539:in `open'
/home/donalo/.rbenv/versions/2.6.2/lib/ruby/2.6.0/net/smtp.rb:539:in `tcp_socket'
/home/donalo/.rbenv/versions/2.6.2/lib/ruby/2.6.0/net/smtp.rb:549:in `block in do_start'
/home/donalo/.rbenv/versions/2.6.2/lib/ruby/2.6.0/timeout.rb:93:in `block in timeout'
/home/donalo/.rbenv/versions/2.6.2/lib/ruby/2.6.0/timeout.rb:103:in `timeout'
/home/donalo/.rbenv/versions/2.6.2/lib/ruby/2.6.0/net/smtp.rb:548:in `do_start'
/home/donalo/.rbenv/versions/2.6.2/lib/ruby/2.6.0/net/smtp.rb:518:in `start'
mail (2.6.6) lib/mail/network/delivery_methods/smtp.rb:111:in `deliver!'
mail (2.6.6) lib/mail/message.rb:2149:in `do_delivery'
mail (2.6.6) lib/mail/message.rb:237:in `block in deliver'
actionmailer (5.2.3) lib/action_mailer/base.rb:560:in `block in deliver_mail'
activesupport (5.2.3) lib/active_support/notifications.rb:168:in `block in instrument'
activesupport (5.2.3) lib/active_support/notifications/instrumenter.rb:23:in `instrument'
activesupport (5.2.3) lib/active_support/notifications.rb:168:in `instrument'
actionmailer (5.2.3) lib/action_mailer/base.rb:558:in `deliver_mail'
mail (2.6.6) lib/mail/message.rb:237:in `deliver'
```