### PR TITLE
Fetch SMTP auth method from APP_CONFIG

### DIFF
--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -129,7 +129,7 @@ Rails.application.configure do
       :domain               => APP_CONFIG.smtp_email_domain,
       :user_name            => APP_CONFIG.smtp_email_user_name,
       :password             => APP_CONFIG.smtp_email_password,
-      :authentication       => 'plain',
+      :authentication       => APP_CONFIG.smtp_email_auth,
       :enable_starttls_auto => true
     }
   end


### PR DESCRIPTION
We found out Nexica's smtp only supports AUTH LOGIN. So we need to abstract the config so we can pass and ENV var along the other SMTP ones.