### PR TITLE
Enable Stripe through a rake task and seed data

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,0 +1,1 @@
+Rake::Task['stripe:enable'].invoke

--- a/lib/tasks/stripe.rake
+++ b/lib/tasks/stripe.rake
@@ -1,0 +1,18 @@
+namespace :stripe do
+  desc 'Enable stripe'
+  task enable: :environment do
+    community_id = Community.find_by_ident('donalo').id
+
+    TransactionService::API::Api.processes.create(
+      community_id: community_id,
+      process: :preauthorize,
+      author_is_seller: true
+    )
+    TransactionService::API::Api.settings.provision(
+      community_id: community_id,
+      payment_gateway: :stripe,
+      payment_process: :preauthorize,
+      active: true
+    )
+  end
+end


### PR DESCRIPTION
Sometimes we'll need to enable it for a server that already has a DB
setup and can't be dropped (like next.donalo.org right now). Often
times, we'll need to setup a new server from scratch (production or
staging) and the DB needs to be in this certain state: Stripe enabled.