### PR TITLE
Reduce CI parallel jobs to fit the freemium

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 jobs:
   test:
-    parallelism: 8
+    parallelism: 4
     # Call bash as interactive login shell to make sure nvm is loaded through .bashrc
     shell: /bin/bash -ileo pipefail
     resource_class: small


### PR DESCRIPTION
Sharetribe has 8 but CircleCI only gives you 4 for free. This change got introduced in Sharetribe's 9.1 release.