### PR TITLE
Fix inconsistent marketplace seeding

### DIFF
--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -536,7 +536,13 @@ class Community < ApplicationRecord
 
   #returns full domain without protocol
   def full_domain(options= {})
-    APP_CONFIG.domain
+    domain = APP_CONFIG.domain
+
+    if options[:with_protocol]
+      domain = "#{(APP_CONFIG.always_use_ssl.to_s == "true" ? "https://" : "http://")}#{domain}"
+    end
+
+    domain
   end
 
   # returns the community specific service name if such is in use

--- a/config/config.yml
+++ b/config/config.yml
@@ -10,6 +10,7 @@
 
 development:
   # Add local `development` environment configuration overrides here
+  domain: "0.0.0.0:3000"
 
 test:
   # Add local `test` environment configuration overrides here

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,43 +1,28 @@
-community = Community.create!(
-  ident: "donalo",
-  domain: nil,
-  settings: {"locales"=>["es"]},
-  consent: "SHARETRIBE1.0",
-  country: "ES",
-  logo_file_name: "Logo_donalo_RGB.png",
-  logo_content_type: "image/png",
-  logo_file_size: 9763,
-  logo_updated_at: "2020-03-06 10:37:20",
-  cover_photo_file_name: "soap-bubbles-1451092_1920.jpg",
-  cover_photo_content_type: "image/jpeg",
-  cover_photo_file_size: 461961,
-  cover_photo_updated_at: "2019-12-23 10:55:22",
-  custom_color1: "5fa645",
-  currency: "EUR",
-  hide_expiration_date: false,
-  name_display_type: "first_name_with_initial",
-  wide_logo_file_name: "Logo_donalo_RGB_rectangular_web.png",
-  wide_logo_content_type: "image/png",
-  wide_logo_file_size: 1719,
-  automatic_confirmation_after_days: 14,
-  favicon_file_name: "circulo.png",
-  favicon_content_type: "image/png",
-  favicon_file_size: 359014,
-  favicon_updated_at: "2020-03-06 10:33:29",
-  custom_head_script: "",
-  logo_processing: false,
-  wide_logo_processing: false,
-  cover_photo_processing: false,
-  favicon_processing: false
+marketplace = MarketplaceService.create(
+  marketplace_name: 'donalo',
+  marketplace_type: 'product',
+  marketplace_country: 'ES',
+  marketplace_language: 'es'
 )
-community.community_customizations << CommunityCustomization.new(
-  locale: "es",
-  name: "donalo",
-  slogan: "El Marketplace de la Economía Circular",
-  description: "donalo.org, un punto de encuentro digital en el que las empresas donan sus excedentes (restos de stock, material informático, mobiliario…)  en buen estado y las Entidades sin Ánimo de Lucro lo reciben gratuitamente. Es un proyecto basado en la economía circular: convertimos residuos en recursos. El proceso está totalmente trazado para calcular el impacto ambiental y los beneficios sociales. ",
-  how_to_use_page_content: "<h1>Cómo funciona</h1><div><h3><u><strong>EMPRESAS&nbsp;</strong></u></h3><div><u><strong><br></strong></u></div><h3><strong>¿QUIÉN PUEDE DONAR PRODUCTO?</strong></h3><div><p>Cualquier empresa con sede o residencia en España</p><div>&nbsp;</div></div><h3><strong>¿POR QUÉ DONAR PRODUCTO?</strong></h3><p>Dar productos, mobiliario o material no sólo ayuda a los más vulnerables y a la sociedad en su conjunto, sino que contribuye a la preservación del medio ambiente y a generar empleo a través de la economía circular.</p><p>&nbsp;</p><h3><strong>¿PUEDO DONAR CUALQUIER COSA?</strong></h3><div>No. En donalo.org no puedes donar alimentos ni productos perecederos. En cambio, puedes donar:&nbsp;muebles, juguetes, material escolar, utensilios&nbsp;de cocina, productos de higiene, electrodomésticos, móviles, libros, cd´s, dvd´s... siempre que estén en buenas condiciones. En el caso de los ordenadores, éstos no deben tener más de ocho años de antigüedad.</div><p>&nbsp;</p><h3><strong>¿QUÉ PRODUCTOS SON LOS MÁS ÚTILES PARA LAS ONG?</strong></h3><div>Los productos más solicitados por las entidades no lucrativas son: equipos informáticos y electrónicos, mobiliario de oficina, muebles, electrodomésticos, juguetes y material escolar. Puedes ver el listado de necesidades publicadas por las ONG&nbsp;<a href=\"http://www.donalo.org/es/necesidades/\">aquí</a>.</div><p>&nbsp;</p><p><strong>¿PUEDO DONAR PRODUCTO NUEVO?</strong></p><div>Sí, no es imprescindible que sea producto usado. Algunas empresas optan por donar su stock sobrante. De esta manera, ahorran en costes de almacenaje o destrucción.</div><p>&nbsp;</p><p><strong>¿PUEDO DONAR A MÁS DE UNA ONG A LA VEZ?</strong></p><div>Como empresa, tú eliges a que ONG donar. Una vez recibamos las peticiones de ONG, te las mandaremos para que puedas elegir la causa.&nbsp;</div><p>&nbsp;</p><p><strong>¿DONAR PRODUCTO DESGRAVA FISCALMENTE COMO DONACIÓN EN ESPECIE?</strong></p><div>Sí. En este&nbsp;<a href=\"https://donalo.org/uploads/files/Info%20certificado%20de%20desgravaci%C3%B3n%20fiscal%282%29.docx\">documento</a>&nbsp;encontrarás más detalles. Nosotros te haremos el certificado fiscal.</div><p>&nbsp;</p><p><strong>¿QUIEN SE ENCARGA DE LA RECOGIDA DEL PRODUCTO?</strong></p><div>La ONG, como beneficiaria de la donación, se responsabiliza de la recogida del material y de los costes que puedan derivarse del transporte y/o logística en el día y hora que haya pactado con las empresa.&nbsp;</div><div>&nbsp;</div><div>&nbsp;</div><p><strong>¿PUEDE ENVIAR LA EMPRESA EL PRODUCTO A LA ONG?</strong></p><div>Si. No hay ningún inconveniente. Muchas empresas se encargan del transporte a través de su sistema interno de logística. Simplemente, se ha de poner de acuerdo con la ONG.</div><div>&nbsp;</div><div>&nbsp;</div><div><strong>¿TENGO QUE PAGAR ALGO PARA HACER LA DONACIÓN'?</strong></div><div><div>No.&nbsp;</div><div>&nbsp;</div><div>&nbsp;</div></div><div><strong>¿PUEDO ELEGIR LA ONG A LA QUE DONAR?</strong></div><div>&nbsp;</div><div>Si. Compartiremos contigo las peticiones que han realizado las ONG a tus donaciones para que puedas elegir la causa con la que te sientas más identificado.</div><p>&nbsp;</p><p>&nbsp;</p><h3><b><u>ONG</u></b></h3><div>&nbsp;</div><div><strong>¿QUÉ ENTIDADES PUEDEN RECIBIR PRODUCTO?</strong></div><div>&nbsp;</div><div>Todas las entidades no lucrativas legalmente constituidas y con sede en España. Al darte de alta, es necesario dar el registro oficial de la organización, ya que es el número que acredita el carácter no lucrativo de la entidad. Asimismo, se debe aportar el CIF.</div><p>&nbsp;</p><div><strong>¿QUÉ TIPO DE PRODUCTO PUEDO SOLICITAR EN NECESIDADES?</strong></div><div>&nbsp;</div><div>Productos no alimenticios ni perecederos, tales como: muebles, antigüedades, juguetes, material escolar, utensilios&nbsp;de cocina, productos de higiene, electrodomésticos, ordenadores, móviles, libros, cd´s, dvd´s. También puedes solicitar producto más concreto y específico, como pañales, leche en polvo, equipamientos...</div><p>&nbsp;</p><div><strong>¿CÓMO SÉ SI SE HA ADJUDICADO ALGÚN EXCEDENTE A MI ORGANIZACIÓN?</strong></div><div>&nbsp;</div><div>Recibirás un correo electrónico en el que se te informará de todos los detalles de la asignación. En caso contrario, también recibirás un e-mail.&nbsp;</div><div>&nbsp;</div><div>&nbsp;</div><div><div><b>¿CÓMO RECIBIRÉ LA DONACIÓN? ¿TENGO QUE IR A RECOGER EL PRODUCTO?</b></div><div>&nbsp;</div><div>La ONG, como beneficiaria de la donación, se responsabiliza de la recogida del material y de los costes que puedan derivarse del transporte y/o logística. Aunque hay algunas empresas que se encargan del transporte gracias a su logística interna (este punto hay que pactarlo).&nbsp;</div></div><div><div>&nbsp;</div><div>&nbsp;</div><div><div><b>¿QUÉ PUEDO HACER SI NO TENGO MEDIO DE TRANSPORTE PARA RECOGER EL PRODUCTO?</b></div><div>&nbsp;</div><div>Contacta con una empresa de transporte. Las empresas de transporte más conocidas, asiduamente ofrecen tarifas especiales para entidades sin ánimo de lucro y algunas cuentas con un servicio solidario a coste 0. Siempre puedes pedir el favor a alguien cercano a la organización (voluntarios, patronos...)</div><div>&nbsp;</div><div>&nbsp;</div></div><div><div><b>¿QUÉ OCURRE SI MI ORGANIZACIÓN NO ESTÁ CERCA DE LA EMPRESA QUE HACE LA DONACIÓN?</b></div><div><div>&nbsp;</div><div>Si no puedes encargarte de recoger el producto, ni puedes mandar a un mensajero, se asignará la donación a otra entidad. ¡Ojo! Presta atención a los datos de recogida del producto que te interese.</div></div></div></div><p>&nbsp;</p><p><b>¿TENGO QUE PAGAR ALGO PARA RECIBIR EL PRODUCTO?</b></p><p>Los únicos costes para la organización son los que puedan derivarse del transporte y/o logística. Sin embargo, los ordenadores sí tienen un coste simbólico, entre 60 y 90 euros, que corresponde al precio de los servicios de preparación para la reutilización.&nbsp;</p><p>&nbsp;</p><p><b>¿A QUÉ ME COMPROMETO CUANDO ME DOY DE ALTA EN DONALO.ORG?</b></p><p>Te comprometes a no comercializar o redistribuir gratuitamente los productos que consigas y a emitir un feed back a la empresa y Fundación real dreams sobre el uso del material donado.</p><h3>&nbsp;</h3><p><b>¿ES OBLIGATORIO EXPLICAR QUÉ HE HECHO CON LA DONACIÓN?</b></p><p>Si. Debes enviarnos fotos e información de tu organización o del proyecto al que se ha destinado el producto donado. Nosotros le daremos difusión a través de las redes sociales y le enviaremos toda la información a la empresa. Dar feed back genera confianza y transparencia en tu gestión. Además, cuanta más transparencia, más posibilidades tendrás para acceder a futuras donaciones.&nbsp;</p><div>&nbsp;</div><div><p><b>¿QUÉ HAGO SI HAY ALGÚN PROBLEMA?</b></p><div>Escríbenos un correo a info@donalo.org</div></div></div>",
-  about_page_content: "<h2>Sobre Donalo.org</h2>\n" +
-  "<p><a href=\"http://www.fundacionrealdreams.org/\"><strong>Fundación real dreams</strong></a>&nbsp;ha creado donalo.org<strong>,&nbsp;</strong>un punto de encuentro digital en el que las empresas donan sus excedentes (restos de stock, material informático, mobiliario…) &nbsp;en buen estado y las Entidades sin Ánimo de Lucro lo reciben gratuitamente. Es un proyecto basado en la economía circular: convertimos residuos en recursos. El proceso está totalmente trazado para calcular el impacto ambiental y los beneficios sociales.&nbsp;</p><p>Es un proyecto que persigue generar una relación win to win en la que todos ganan:</p><p>&nbsp;</p><p><strong>EMPRESAS</strong></p><ul><li>Ahorran en el coste de almacenaje o destrucción del excedente</li><li>Desgravan el material donado</li><li>Incorporan la acción a su RSC</li></ul><p>&nbsp;</p><p><strong>ENTIDADES NO LUCRATIVAS</strong></p><ul><li>Acceden a productos en buen estado sin coste alguno</li><li>Destinan el presupuesto liberado al proyecto de acción social</li><li>Ejercen de puente para que sus beneficiarios puedan recibir el material donado</li></ul><p>&nbsp;</p><p><strong>MEDIO AMBIENTE</strong></p><p></p><ul><li>Se da una segunda vida útil a productos en buen estado</li><li>Se reducen las emisiones de CO2&nbsp;porque se evita la destrucción de los materiales</li><li>Se conciencia sobre la necesidad de reducir, reutilizar y reciclar recursos</li></ul><p></p>"
+user = UserService::API::Users.create_user(
+  {
+    given_name: 'Troy',
+    family_name: 'McClure',
+    email: 'donalo@example.com',
+    password: 'papapa22',
+    locale: 'es'
+  },
+  marketplace.id
+)
+user = user.data
+
+auth_token = UserService::API::AuthTokens.create_login_token(user[:id])
+auth_token = AuthToken.first
+user_token = auth_token[:token]
+url = URLUtils.append_query_param(
+  marketplace.full_domain(with_protocol: true), "auth", user_token
 )
 
 Rake::Task['stripe:enable'].invoke
+
+puts "\n\e[33mYou can now navigate to your markeplace at #{url}"


### PR DESCRIPTION
I had to replace the manually created Community with the logic Sharetribe uses to setup the marketplace from the UI. When you visit the home page with an empty DB, the HomeController uses a couple services to set things up. It does create more records than we did.

This, as a result, leaves you with a consistent development marketplace but it does not recreate Donalo as I initially intended. It gives you an onboarding progressed to the 14% percent (there's a top bar in the UI). That can come after as a bunch of `update_attributes` calls on top of this to store images and other customizations. Now I need this to develop.
    
I also needed to restore part of the logic we removed in 9356d70e9846be5c2cb5c0e1a8e7439e0dc35291.
    
Now, when you run `db:seed` you'll see the following message:
    
```
You can now navigate to your markeplace at http://0.0.0.0:3000?auth=_KOg0lTLSUc
```