### PR TITLE
Do not configure Thinking Sphinx twice

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -54,7 +54,7 @@ services:
       context: .
       dockerfile: Dockerfile.dev
     command: >
-      bash -c "bundle exec rake ts:configure ts:index; \
+      bash -c "bundle exec rake ts:index; \
                searchd --pidfile \
                        --config config/development.sphinx.conf; \
                bundle exec rake jobs:work"


### PR DESCRIPTION
`ts:index` already calls `ts:configure`

```
rake ts:configure # Generate the Sphinx configuration file
rake ts:index # Generate the Sphinx configuration file and process all indices
```