### PR TITLE
Don't enforce dev RAILS_ENV

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -29,7 +29,6 @@ services:
     depends_on:
       - mysql
     environment:
-      RAILS_ENV: development
       DATABASE_URL: mysql2://sharetribe:secret@mysql/sharetribe_development
       SPHINX_HOST: worker_and_search
   rails-client-assets:


### PR DESCRIPTION
This way tests can be executed without having to specify RAILS_ENV=test each time. The spec_helper.rb does that already, only if it's not defined yet.
    
As a result you can run specs with docker like
    
```
$ docker-compose exec web bundle exec rspec spec/
```
    
Without having `NameError`s for all testing gems like `NameError: uninitialized constant DatabaseCleaner` or `NameError: uninitialized constant Timecop`.