### PR TITLE
Fix dev env setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,8 @@ docker-compose up
 The first time you'll need to create and initialize the database as follows:
 
 ```bash
-docker-compose run web bundle exec rake db:create db:structure:load db:seed
+docker-compose exec web bundle exec rake db:create db:structure:load db:seed
 ```
-
-Note the tasks executed above fail for the test database and you might need to run them separately until that's fixed.
 
 Now, follow the message `db:seed` outputs to log into the marketplace and you'll be good to go.
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -13,9 +13,9 @@ test: &test
     adapter: mysql2
     database: sharetribe_test
     encoding: utf8
-    username: # ADD DATABASE USERNAME
-    password: # ADD DATABASE PASSWORD
-    host: localhost
+    username: root
+    password: secret
+    host: mysql
 
 staging:
     adapter: mysql2


### PR DESCRIPTION
When executing db's rake tasks Rails is looking up the connection details on the config/database.yml instead of the DATABASE_URL env var.