### PR TITLE
Disable payment receipt to seller

### DIFF
--- a/engines/donalo/lib/donalo/engine.rb
+++ b/engines/donalo/lib/donalo/engine.rb
@@ -26,7 +26,7 @@ module Donalo
       module ::StripeHelper
         class << self
           def user_stripe_active?(community_id, person_id)
-            return true
+            true
           end
         end
       end

--- a/engines/donalo/lib/donalo/engine.rb
+++ b/engines/donalo/lib/donalo/engine.rb
@@ -13,6 +13,14 @@ module Donalo
         ::StripeService::Report
       ]
 
+      module SendPaymentReceiptsOverride
+        def seller_should_receive_receipt(_seller_id)
+          false
+        end
+      end
+
+      ::SendPaymentReceipts.prepend(SendPaymentReceiptsOverride)
+
       # StripeHelper.user_active_true? to always return true, so the
       # users don't need to setup their payment setings
       module ::StripeHelper


### PR DESCRIPTION
We got superlucky here. The code checks whether the receipt needs to be sent to the seller using this method :ok_hand: 

https://github.com/coopdevs/sharetribe/blob/ac429b4f7c85a66f07f90d4310fd17dc2fb2f642/app/jobs/send_payment_receipts.rb#L13-L18

For Donalo it'll have a different meaning. Now it has this

https://github.com/coopdevs/sharetribe/blob/ac429b4f7c85a66f07f90d4310fd17dc2fb2f642/app/jobs/send_payment_receipts.rb#L30-L32