### PR TITLE
Remove sqlite3 dependency from Donalo engine

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,7 +24,6 @@ PATH
     donalo (0.1.0)
       mysql2 (~> 0.4.1)
       rails (~> 5.2.3)
-      sqlite3
 
 GEM
   remote: https://rubygems.org/
@@ -566,7 +565,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sqlite3 (1.4.2)
     statesman (2.0.1)
     stringex (2.7.1)
     stripe (4.9.0)

--- a/engines/donalo/Gemfile.lock
+++ b/engines/donalo/Gemfile.lock
@@ -4,7 +4,6 @@ PATH
     donalo (0.1.0)
       mysql2 (~> 0.4.1)
       rails (~> 5.2.3)
-      sqlite3
 
 GEM
   remote: https://rubygems.org/
@@ -128,7 +127,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sqlite3 (1.4.2)
     thor (1.0.1)
     thread_safe (0.3.6)
     tzinfo (1.2.7)

--- a/engines/donalo/donalo.gemspec
+++ b/engines/donalo/donalo.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "mysql2", "~> 0.4.1"
   spec.add_dependency "rails", "~> 5.2.3"
-  spec.add_dependency "sqlite3"
 
   spec.add_development_dependency "rspec-rails"
 end


### PR DESCRIPTION
It breaks deployments because sqlite3's gem native extensions can't be installed. It needs the `libsqlite3-dev` package.

This gem was only left when setting up RSpec in the engine but the gemspec already defines the dependency on mysql2. No need then for sqlite3 either in test or production.