### PR TITLE
Make Rails find assets to be compiled

### DIFF
--- a/engines/donalo/lib/donalo/engine.rb
+++ b/engines/donalo/lib/donalo/engine.rb
@@ -12,6 +12,8 @@ module Donalo
       end
     end
 
+    config.assets.precompile += %w(donalo/styles.css donalo/styles-non-admin.css)
+
     # centralized payments
     initializer "donalo/monkey_patch/centralized_payments" do |app|
       next unless defined?(::StripeHelper)
@@ -126,8 +128,6 @@ module Donalo
           @stripe_account ||= MockStripeAccount.new
         end
       end
-
-      app.config.assets.precompile += %w(donalo/styles.css donalo/styles-non-admin.css)
     end
 
     # stock control


### PR DESCRIPTION
For some reason, Rails doesn't find the engine's CSSs that need to be compiled. This needs to be investigated further as this used to work and these are being compiled in next.donalo.org.

This is what raises

![Screenshot from 2020-07-06 17-24-20](https://user-images.githubusercontent.com/762088/86612131-f0e5de80-bfaf-11ea-9e05-dd5fff01468e.png)
