### PR TITLE
Remove tests-related defensive coding

### DIFF
--- a/engines/donalo/lib/donalo/engine.rb
+++ b/engines/donalo/lib/donalo/engine.rb
@@ -14,7 +14,6 @@ module Donalo
 
     # centralized payments
     initializer "donalo/monkey_patch/centralized_payments" do |app|
-      next unless defined?(::StripeHelper)
 
       # referencing monkey patched modules to ensure they are loaded
       PATCHED_OBJECTS = [
@@ -132,8 +131,6 @@ module Donalo
 
     # stock control
     initializer "donalo/monkey_patch/stock_control" do |app|
-      next unless defined?(::Listing)
-
       Donalo.app_root = app.root
 
       PATCHED_OBJECTS = [


### PR DESCRIPTION
The order in which the initializer blocks are called doesn't seem to be
deterministic and now, `Listing` is not yet loaded when the
"donalo/monkey_patch/stock_control" is called thus, the stock feature is
never loaded.

We'll need to see how this affects the tests and find a better way to
distinguish between production and test.