### PR TITLE
Store assets in filesystem instead of S3

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -148,5 +148,5 @@ Rails.application.configure do
   # We don't need schema dumps in this environment
   config.active_record.dump_schema_after_migration = false
 
-  config.active_storage.service = :amazon
+  config.active_storage.service = :local
 end


### PR DESCRIPTION
This needs to be investigated further. Sharetribe should allow everyone
to choose their approach and not force S3.

The solution should be to move that to APP_CONFIG and let people choose.