### PR TITLE
Pass the filesize limit to jQuery's fileupload

### DIFF
--- a/app/assets/javascripts/image_uploader.js
+++ b/app/assets/javascripts/image_uploader.js
@@ -345,7 +345,8 @@ window.ST.imageUploader = function(listings, opts) {
       // Enable image resizing, except for Android and Opera,
       // which actually support image resizing, but fail to
       // send Blob objects via XHR requests:
-      disableImageResize: /Android(?!.*Chrome)|Opera/.test(window.navigator && navigator.userAgent)
+      disableImageResize: /Android(?!.*Chrome)|Opera/.test(window.navigator && navigator.userAgent),
+      maxFileSize: 10000000 // Duplicate from config/config.yml and the `max_image_filesize` env var.
     };
 
     var fileuploadOptions = _.extend(fileuploadDefaultOptions, additionalOptions);


### PR DESCRIPTION
This performs a client-side validation and displays "El archivo es demasiado grande" in the drop area. There doesn't seem to be a way to print the error the backend returns because fileupload's `fail` callback doesn't provide any arguments.