### PR TITLE
Enable community footer

### DIFF
--- a/db/migrate/20200608104047_enable_customizable_footer.rb
+++ b/db/migrate/20200608104047_enable_customizable_footer.rb
@@ -1,22 +1,31 @@
 class EnableCustomizableFooter < ActiveRecord::Migration[5.2]
   # Note this assumes the external_plan_service_in_use setting is set to true.
   # This migration alone won't enable it.
-  COMMUNITY_ID = Community.first.id
-
   def up
     PlanService::Store::Plan::PlanModel.create(
-      community_id: COMMUNITY_ID,
+      community_id: community.id,
       status: "active",
       features: {"whitelabel"=>true, "admin_email"=>true, "footer"=>true},
       expires_at: Time.current + 20.years
     )
+    community.footer_enabled = true
+    community.save!
   end
 
   def down
+    community.footer_enabled = false
+    community.save!
+
     current_plan = PlanService::Store::Plan::PlanModel.where(
-      community_id: COMMUNITY_ID,
+      community_id: community.id,
       status: 'active'
     ).first
     current_plan.destroy
+  end
+
+  private
+
+  def community
+    @community ||= Community.first
   end
 end


### PR DESCRIPTION
Having a plan model with the `footer` feature alone doesn't enable it. The community needs to enable it either from `/es/admin/footer/edit` or this way.