### PR TITLE
Update people view to get email from emails table

### DIFF
--- a/db/migrate/20201217145426_update_masked_people_to_version_3.rb
+++ b/db/migrate/20201217145426_update_masked_people_to_version_3.rb
@@ -1,0 +1,5 @@
+class UpdateMaskedPeopleToVersion3 < ActiveRecord::Migration[5.2]
+  def change
+    update_view :masked_people, version: 3, revert_to_version: 2
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1568,7 +1568,7 @@ CREATE TABLE `transactions` (
 /*!50001 SET character_set_results     = utf8 */;
 /*!50001 SET collation_connection      = utf8_general_ci */;
 /*!50001 CREATE ALGORITHM=UNDEFINED */
-/*!50001 VIEW `masked_people` AS select `people`.`id` AS `id`,`people`.`uuid` AS `uuid`,`people`.`created_at` AS `created_at`,`people`.`updated_at` AS `updated_at`,`people`.`is_admin` AS `is_admin`,`people`.`locale` AS `locale`,`people`.`preferences` AS `preferences`,`people`.`active_days_count` AS `active_days_count`,`people`.`last_page_load_date` AS `last_page_load_date`,`people`.`test_group_number` AS `test_group_number`,`people`.`username` AS `username`,`people`.`reset_password_sent_at` AS `reset_password_sent_at`,`people`.`remember_created_at` AS `remember_created_at`,`people`.`sign_in_count` AS `sign_in_count`,`people`.`current_sign_in_at` AS `current_sign_in_at`,`people`.`last_sign_in_at` AS `last_sign_in_at`,`people`.`given_name` AS `given_name`,`people`.`family_name` AS `family_name`,`people`.`display_name` AS `display_name`,`people`.`phone_number` AS `phone_number`,`people`.`description` AS `description`,`people`.`image_updated_at` AS `image_updated_at`,`people`.`email` AS `email` from `people` */;
+/*!50001 VIEW `masked_people` AS select `people`.`id` AS `id`,`people`.`uuid` AS `uuid`,`people`.`created_at` AS `created_at`,`people`.`updated_at` AS `updated_at`,`people`.`is_admin` AS `is_admin`,`people`.`locale` AS `locale`,`people`.`preferences` AS `preferences`,`people`.`active_days_count` AS `active_days_count`,`people`.`last_page_load_date` AS `last_page_load_date`,`people`.`test_group_number` AS `test_group_number`,`people`.`username` AS `username`,`people`.`reset_password_sent_at` AS `reset_password_sent_at`,`people`.`remember_created_at` AS `remember_created_at`,`people`.`sign_in_count` AS `sign_in_count`,`people`.`current_sign_in_at` AS `current_sign_in_at`,`people`.`last_sign_in_at` AS `last_sign_in_at`,`people`.`given_name` AS `given_name`,`people`.`family_name` AS `family_name`,`people`.`display_name` AS `display_name`,`people`.`phone_number` AS `phone_number`,`people`.`description` AS `description`,`people`.`image_updated_at` AS `image_updated_at`,`emails`.`address` AS `email` from (`people` join `emails` on((`emails`.`person_id` = `people`.`id`))) */;
 /*!50001 SET character_set_client      = @saved_cs_client */;
 /*!50001 SET character_set_results     = @saved_cs_results */;
 /*!50001 SET collation_connection      = @saved_col_connection */;
@@ -2482,6 +2482,7 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20200608104047'),
 ('20200609150707'),
 ('20200706144036'),
-('20200723183953');
+('20200723183953'),
+('20201217145426');
 
 

--- a/db/views/masked_people_v03.sql
+++ b/db/views/masked_people_v03.sql
@@ -1,0 +1,27 @@
+SELECT
+  people.id,
+  people.uuid,
+  people.created_at,
+  people.updated_at,
+  people.is_admin,
+  people.locale,
+  people.preferences,
+  people.active_days_count,
+  people.last_page_load_date,
+  people.test_group_number,
+  people.username,
+  people.reset_password_sent_at,
+  people.remember_created_at,
+  people.sign_in_count,
+  people.current_sign_in_at,
+  people.last_sign_in_at,
+  people.given_name,
+  people.family_name,
+  people.display_name,
+  people.phone_number,
+  people.description,
+  people.image_updated_at,
+  emails.address AS email
+FROM people
+INNER JOIN emails
+  ON emails.person_id = people.id

--- a/features/support/env.rb.database_cleanup.rb
+++ b/features/support/env.rb.database_cleanup.rb
@@ -51,7 +51,7 @@ def clean_db
 end
 
 def set_strategy(strategy)
-  DatabaseCleaner.strategy = strategy
+  DatabaseCleaner.strategy = strategy, { except: %w[masked_people] }
   Cucumber::Rails::Database.javascript_strategy = strategy
 end
 


### PR DESCRIPTION
The column is there but empty (no user has it set in the production DB). It turns out it is stored in the `emails` table. This supports users having multiple emails, I suspect to enable a single user having access to multiple communities.

We don't care about this since there's only a community for Donalo so we can safely assume a one to one relationship between person and email records.

This fixes what I did on https://github.com/coopdevs/sharetribe/pull/76. I went to fast and didn't double check things :sweat: 