### PR TITLE
Whitelist masked_people DB view when cleaning DB

### DIFF
--- a/features/support/env.rb.database_cleanup.rb
+++ b/features/support/env.rb.database_cleanup.rb
@@ -45,7 +45,7 @@ end
 Mysql2::Client.prepend(MutexLockedQuerying)
 
 def clean_db
-  DatabaseCleaner.clean_with :deletion
+  DatabaseCleaner.clean_with :deletion, { except: %w[masked_people] }
   load_default_test_data_to_db_before_suite
   load_default_test_data_to_db_before_test
 end


### PR DESCRIPTION
Cucumber tests are failing as follows due to the `masked_people` DB view

```
shopt -s globstar && mkdir -p $CIRCLE_TEST_REPORTS/cucumber && bundle exec cucumber --tags "not @excluded" -p ci --format json --out $CIRCLE_TEST_REPORTS/cucumber/tests.cucumber $(circleci tests glob features/**/*.feature | circleci tests split --split-by=timings --show-counts)
Read 102 lines of autodetect(s)
Autodetected filename timings.
Bucket 1: assigning 26 autodetect(s), total weight 253015625
Deprecated: Found tags option '~@pending'. Support for '~@tag' will be removed from the next release of Cucumber. Please use 'not @tag' instead.
Deprecated: Found tags option '~@fix_for_new_design'. Support for '~@tag' will be removed from the next release of Cucumber. Please use 'not @tag' instead.
/home/circleci/project/engines/donalo/lib/donalo/engine.rb:136: warning: already initialized constant Donalo::Engine::PATCHED_OBJECTS
/home/circleci/project/engines/donalo/lib/donalo/engine.rb:19: warning: previous definition of PATCHED_OBJECTS was here
Mysql2::Error: Can not delete from join view 'sharetribe_test.masked_people': DELETE FROM `masked_people`; (ActiveRecord::StatementInvalid)
/home/circleci/project/vendor/bundle/gems/mysql2-0.4.10/lib/mysql2/client.rb:120:in `_query'
/home/circleci/project/vendor/bundle/gems/mysql2-0.4.10/lib/mysql2/client.rb:120:in `block in query'
/home/circleci/project/vendor/bundle/gems/mysql2-0.4.10/lib/mysql2/client.rb:119:in `handle_interrupt'
/home/circleci/project/vendor/bundle/gems/mysql2-0.4.10/lib/mysql2/client.rb:119:in `query'
/home/circleci/project/features/support/env.rb.database_cleanup.rb:41:in `block in query'
/home/circleci/project/features/support/env.rb.database_cleanup.rb:41:in `synchronize'
/home/circleci/project/features/support/env.rb.database_cleanup.rb:41:in `query'
/home/circleci/project/vendor/bundle/gems/activerecord-5.2.3/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:187:in `block (2 levels) in execute'
/home/circleci/project/vendor/bundle/gems/activesupport-5.2.3/lib/active_support/dependencies/interlock.rb:48:in `block in permit_concurrent_loads'
/home/circleci/project/vendor/bundle/gems/activesupport-5.2.3/lib/active_support/concurrency/share_lock.rb:187:in `yield_shares'
/home/circleci/project/vendor/bundle/gems/activesupport-5.2.3/lib/active_support/dependencies/interlock.rb:47:in `permit_concurrent_loads'
/home/circleci/project/vendor/bundle/gems/activerecord-5.2.3/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:186:in `block in execute'
/home/circleci/project/vendor/bundle/gems/activerecord-5.2.3/lib/active_record/connection_adapters/abstract_adapter.rb:581:in `block (2 levels) in log'
/usr/local/lib/ruby/2.6.0/monitor.rb:235:in `mon_synchronize'
/home/circleci/project/vendor/bundle/gems/activerecord-5.2.3/lib/active_record/connection_adapters/abstract_adapter.rb:580:in `block in log'
/home/circleci/project/vendor/bundle/gems/activesupport-5.2.3/lib/active_support/notifications/instrumenter.rb:23:in `instrument'
/home/circleci/project/vendor/bundle/gems/activerecord-5.2.3/lib/active_record/connection_adapters/abstract_adapter.rb:571:in `log'
/home/circleci/project/vendor/bundle/gems/activerecord-5.2.3/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:185:in `execute'
/home/circleci/project/vendor/bundle/gems/activerecord-5.2.3/lib/active_record/connection_adapters/mysql/database_statements.rb:28:in `execute'
/home/circleci/project/vendor/bundle/gems/database_cleaner-1.6.1/lib/database_cleaner/active_record/deletion.rb:17:in `delete_table'
/home/circleci/project/vendor/bundle/gems/connection_pool-2.2.2/lib/connection_pool.rb:157:in `block in method_missing'
/home/circleci/project/vendor/bundle/gems/connection_pool-2.2.2/lib/connection_pool.rb:65:in `block (2 levels) in with'
/home/circleci/project/vendor/bundle/gems/connection_pool-2.2.2/lib/connection_pool.rb:64:in `handle_interrupt'
/home/circleci/project/vendor/bundle/gems/connection_pool-2.2.2/lib/connection_pool.rb:64:in `block in with'
/home/circleci/project/vendor/bundle/gems/connection_pool-2.2.2/lib/connection_pool.rb:61:in `handle_interrupt'
/home/circleci/project/vendor/bundle/gems/connection_pool-2.2.2/lib/connection_pool.rb:61:in `with'
/home/circleci/project/vendor/bundle/gems/connection_pool-2.2.2/lib/connection_pool.rb:136:in `with'
/home/circleci/project/vendor/bundle/gems/connection_pool-2.2.2/lib/connection_pool.rb:156:in `method_missing'
/home/circleci/project/vendor/bundle/gems/database_cleaner-1.6.1/lib/database_cleaner/active_record/deletion.rb:101:in `block (2 levels) in clean'
/home/circleci/project/vendor/bundle/gems/database_cleaner-1.6.1/lib/database_cleaner/active_record/deletion.rb:100:in `each'
/home/circleci/project/vendor/bundle/gems/database_cleaner-1.6.1/lib/database_cleaner/active_record/deletion.rb:100:in `block in clean'
/home/circleci/project/vendor/bundle/gems/activerecord-5.2.3/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:156:in `disable_referential_integrity'
/home/circleci/project/vendor/bundle/gems/connection_pool-2.2.2/lib/connection_pool.rb:157:in `block in method_missing'
/home/circleci/project/vendor/bundle/gems/connection_pool-2.2.2/lib/connection_pool.rb:65:in `block (2 levels) in with'
/home/circleci/project/vendor/bundle/gems/connection_pool-2.2.2/lib/connection_pool.rb:64:in `handle_interrupt'
/home/circleci/project/vendor/bundle/gems/connection_pool-2.2.2/lib/connection_pool.rb:64:in `block in with'
/home/circleci/project/vendor/bundle/gems/connection_pool-2.2.2/lib/connection_pool.rb:61:in `handle_interrupt'
/home/circleci/project/vendor/bundle/gems/connection_pool-2.2.2/lib/connection_pool.rb:61:in `with'
/home/circleci/project/vendor/bundle/gems/connection_pool-2.2.2/lib/connection_pool.rb:136:in `with'
/home/circleci/project/vendor/bundle/gems/connection_pool-2.2.2/lib/connection_pool.rb:156:in `method_missing'
/home/circleci/project/vendor/bundle/gems/database_cleaner-1.6.1/lib/database_cleaner/active_record/deletion.rb:99:in `clean'
/home/circleci/project/vendor/bundle/gems/database_cleaner-1.6.1/lib/database_cleaner/base.rb:46:in `clean_with'
/home/circleci/project/vendor/bundle/gems/database_cleaner-1.6.1/lib/database_cleaner/configuration.rb:91:in `block in clean_with'
/home/circleci/project/vendor/bundle/gems/database_cleaner-1.6.1/lib/database_cleaner/configuration.rb:91:in `each'
/home/circleci/project/vendor/bundle/gems/database_cleaner-1.6.1/lib/database_cleaner/configuration.rb:91:in `clean_with'
/home/circleci/project/features/support/env.rb.database_cleanup.rb:48:in `clean_db'
/home/circleci/project/features/support/env.rb.database_cleanup.rb:59:in `<main>'
/home/circleci/project/vendor/bundle/gems/bootsnap-1.4.3/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:54:in `load'
/home/circleci/project/vendor/bundle/gems/bootsnap-1.4.3/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:54:in `load'
/home/circleci/project/vendor/bundle/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:285:in `block in load'
/home/circleci/project/vendor/bundle/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:257:in `load_dependency'
/home/circleci/project/vendor/bundle/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:285:in `load'
/home/circleci/project/vendor/bundle/gems/cucumber-3.1.2/lib/cucumber/glue/registry_and_more.rb:107:in `load_code_file'
(...)
```