### PR TITLE
Upgrade bundler from 1.17 to 2.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -772,4 +772,4 @@ RUBY VERSION
    ruby 2.6.5p114
 
 BUNDLED WITH
-   1.17.3
+   2.1.4


### PR DESCRIPTION
This will hopefully fix the error that is preventing Heroku deployments:

```
/usr/lib/ruby/2.5.0/rubygems.rb:289:in `find_spec_for_exe': Could not find 'bundler' (1.17.3) required by your /app/Gemfile.lock. (Gem::GemNotFoundException)
To update to the lastest version installed on your system, run `bundle update --bundler`.
To install the missing version, run `gem install bundler:1.17.3`
	from /usr/lib/ruby/2.5.0/rubygems.rb:263:in `bin_path'
	from /app/bin/bundle:3:in `<main>'
```