### PR TITLE
Improve seed data

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -26,11 +26,25 @@ url = URLUtils.append_query_param(
   marketplace.full_domain(with_protocol: true), "auth", user_token
 )
 
+Rake::Task['stripe:enable'].invoke
+
+# Enable customizable footer. Note it also needs external_plan_service_in_use
+# set to true.
+PlanService::Store::Plan::PlanModel.create(
+  community_id: marketplace.id,
+  status: "active",
+  features: {"whitelabel"=>true, "admin_email"=>true, "footer"=>true},
+  expires_at: Time.current + 20.years
+)
+
+
+require Rails.root.join('db/seeds/categories.rb')
+
 NumericField.create(
   community: Community.first,
   min: 1,
   max: 999,
-  categories: [Category.first],
+  categories: Category.all,
   search_filter: false,
   names: [
     CustomFieldName.new(
@@ -44,7 +58,7 @@ NumericField.create(
   community: Community.first,
   min: 1,
   max: 999,
-  categories: [Category.first],
+  categories: Category.all,
   search_filter: false,
   names: [
     CustomFieldName.new(
@@ -53,18 +67,5 @@ NumericField.create(
     ),
   ]
 )
-
-Rake::Task['stripe:enable'].invoke
-
-# Enable customizable footer. Note it also needs external_plan_service_in_use
-# set to true.
-PlanService::Store::Plan::PlanModel.create(
-  community_id: marketplace.id,
-  status: "active",
-  features: {"whitelabel"=>true, "admin_email"=>true, "footer"=>true},
-  expires_at: Time.current + 20.years
-)
-
-require Rails.root.join('db/seeds/categories.rb')
 
 puts "\n\e[33mYou can now navigate to your markeplace at #{url}"

--- a/db/seeds/categories.rb
+++ b/db/seeds/categories.rb
@@ -117,3 +117,8 @@ end
 category.translations.find_or_create_by(name: 'Accesorios y ropa') do |translation|
   translation.locale = 'es'
 end
+
+Category.all.each do |category|
+  category.listing_shapes = ListingShape.all
+  category.save!
+end


### PR DESCRIPTION
Read the extended commit messages for details. This will ease setting up a new with `rake db:seed`. At least custom fields and listing shapes will be correctly set up.